### PR TITLE
Add citations to response object

### DIFF
--- a/backend/chat_config.yaml
+++ b/backend/chat_config.yaml
@@ -3,7 +3,26 @@ chat_approach:
   system_prompt: |-
                   Answer the question based only on the following context. 
                   If none of the resources answer the question, then please ask the user to rephrase their question to focus on Container Apps or Tomatoes.
-                  Make sure you cite the source of the information by providing a clickable link to the document's URL.
+
+                  Remember, you must return both an answer and citations. A citation consists of a quote that
+                  justifies the answer and the title and URL of the quoted article. Return a citation for every quote across all articles
+                  that justify the answer. Use the following format for your final output:
+
+                  {{
+                      "answer": "The answer to the question.",
+                      "citations": [
+                          {{
+                              "title": "The title of the source.",
+                              "url": "The URL of the source."
+                          }},
+                          {{
+                              "title": "The title of the source.",
+                              "url": "The URL of the source."
+                          }},
+                          ...
+                      ]
+                  }}
+
                   {context}
   documents:
     primary_index_name: "aca-data"

--- a/backend/chat_config.yaml
+++ b/backend/chat_config.yaml
@@ -4,20 +4,22 @@ chat_approach:
                   Answer the question based only on the following context. 
                   If none of the resources answer the question, then please ask the user to rephrase their question to focus on Container Apps or Tomatoes.
 
-                  Remember, you must return both an answer and citations. A citation consists of a quote that
-                  justifies the answer and the title and URL of the quoted article. Return a citation for every quote across all articles
+                  Remember, you must return both an answer and citations. A citation consists of a VERBATIM quote that
+                  justifies the answer and the ID of the quote article. Return a citation for every quote across all articles
                   that justify the answer. Use the following format for your final output:
 
                   {{
                       "answer": "The answer to the question.",
                       "citations": [
                           {{
-                              "title": "The title of the source.",
-                              "url": "The URL of the source."
+                              "id": "The ID of the source",
+                              "url": "The URL of the source.",
+                              "title": "A short title of the source."
                           }},
                           {{
-                              "title": "The title of the source.",
-                              "url": "The URL of the source."
+                              "id": "The ID of the source",
+                              "url": "The URL of the source.",
+                              "title": "A short title of the source."
                           }},
                           ...
                       ]

--- a/backend/chat_config.yaml
+++ b/backend/chat_config.yaml
@@ -3,7 +3,28 @@ chat_approach:
   system_prompt: |-
                   Answer the question based only on the following context. 
                   If none of the resources answer the question, then please ask the user to rephrase their question to focus on Container Apps or Tomatoes.
-                  Make sure you cite the source of the information by providing a clickable link to the document's URL.
+
+                  Remember, you must return both an answer and citations. A citation consists of a VERBATIM quote that
+                  justifies the answer and the ID of the quote article. Return a citation for every quote across all articles
+                  that justify the answer. Use the following format for your final output:
+
+                  {{
+                      "answer": "The answer to the question.",
+                      "citations": [
+                          {{
+                              "id": "The ID of the source",
+                              "url": "The URL of the source.",
+                              "title": "A short title of the source."
+                          }},
+                          {{
+                              "id": "The ID of the source",
+                              "url": "The URL of the source.",
+                              "title": "A short title of the source."
+                          }},
+                          ...
+                      ]
+                  }}
+
                   {context}
   documents:
     primary_index_name: "aca-data"

--- a/backend/libs/core/approaches/chat_conversation.py
+++ b/backend/libs/core/approaches/chat_conversation.py
@@ -1,7 +1,6 @@
 """Conversation logic for AI Chatbot."""
 from operator import itemgetter
 from langchain_core.runnables import (RunnablePassthrough, RunnableParallel, RunnableLambda)
-from langchain_core.output_parsers import JsonOutputParser
 from libs.core.approaches.multi_index_chat_builder import MultiIndexChatBuilder
 from libs.core.models.options import ChatConversationOptions
 
@@ -32,12 +31,10 @@ def build_chain(
 
     filtered_docs = docs | RunnableLambda(builder.sort_and_filter_documents)
 
-    parser = JsonOutputParser()
-
     chain = {"context" : filtered_docs | builder.format_docs,
             "question": RunnablePassthrough() } | RunnableLambda(lambda info: _route(
         options = chat_options,
         builder = builder,
-        context_info = info)) | parser
+        context_info = info))
 
     return chain

--- a/backend/libs/core/approaches/chat_conversation.py
+++ b/backend/libs/core/approaches/chat_conversation.py
@@ -1,6 +1,7 @@
 """Conversation logic for AI Chatbot."""
 from operator import itemgetter
 from langchain_core.runnables import (RunnablePassthrough, RunnableParallel, RunnableLambda)
+from langchain_core.output_parsers import JsonOutputParser
 from libs.core.approaches.multi_index_chat_builder import MultiIndexChatBuilder
 from libs.core.models.options import ChatConversationOptions
 
@@ -31,10 +32,12 @@ def build_chain(
 
     filtered_docs = docs | RunnableLambda(builder.sort_and_filter_documents)
 
+    parser = JsonOutputParser()
+
     chain = {"context" : filtered_docs | builder.format_docs,
             "question": RunnablePassthrough() } | RunnableLambda(lambda info: _route(
         options = chat_options,
         builder = builder,
-        context_info = info))
+        context_info = info)) | parser
 
     return chain

--- a/backend/libs/core/approaches/multi_index_chat_builder.py
+++ b/backend/libs/core/approaches/multi_index_chat_builder.py
@@ -99,6 +99,7 @@ class MultiIndexChatBuilder:
             container = d[0].metadata["container"]
 
             sas_token = self._token_service.get_sas_token_for_blob(file_name, container)
+            formatted_docs += f'TITLE: {file_name}\n'
             formatted_docs += f'URL: {url}/{container}/{file_name}?{sas_token}'
             formatted_docs += f'CONTENT: {d[0].page_content}\n\n'
         return formatted_docs

--- a/backend/libs/core/approaches/multi_index_chat_builder.py
+++ b/backend/libs/core/approaches/multi_index_chat_builder.py
@@ -93,13 +93,13 @@ class MultiIndexChatBuilder:
     def format_docs(self, docs):
         """Function to format the documents into a string, with the URL included for citations"""
         formatted_docs = ""
-        for d in docs:
+        for i, d in enumerate(docs):
             url = self._storage_account_options.url
             file_name = d[0].metadata["file_name"]
             container = d[0].metadata["container"]
 
             sas_token = self._token_service.get_sas_token_for_blob(file_name, container)
-            formatted_docs += f'TITLE: {file_name}\n'
+            formatted_docs += f'ID: {i}'
             formatted_docs += f'URL: {url}/{container}/{file_name}?{sas_token}'
             formatted_docs += f'CONTENT: {d[0].page_content}\n\n'
         return formatted_docs

--- a/backend/libs/core/approaches/multi_index_chat_builder.py
+++ b/backend/libs/core/approaches/multi_index_chat_builder.py
@@ -93,12 +93,13 @@ class MultiIndexChatBuilder:
     def format_docs(self, docs):
         """Function to format the documents into a string, with the URL included for citations"""
         formatted_docs = ""
-        for d in docs:
+        for i, d in enumerate(docs):
             url = self._storage_account_options.url
             file_name = d[0].metadata["file_name"]
             container = d[0].metadata["container"]
 
             sas_token = self._token_service.get_sas_token_for_blob(file_name, container)
+            formatted_docs += f'ID: {i}'
             formatted_docs += f'URL: {url}/{container}/{file_name}?{sas_token}'
             formatted_docs += f'CONTENT: {d[0].page_content}\n\n'
         return formatted_docs

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,10 @@
 """Main module for the FastAPI application."""
+import json
 from fastapi import FastAPI
 
 from models.rate_models import RateRequest
 from models.chat_request import ChatRequest
+from models.llm_response import LlmResponse
 from models.chat_response import (
     Answer,
     AnswerQueryConfig,
@@ -54,8 +56,12 @@ def conversation(chat_message: ChatRequest):
     )
 
     response = chain.invoke({"question": chat_message.dialog})
+    json_content = json.loads(response.content)
+    llm_response = LlmResponse(**json_content)
+
     chat_answer = Answer(
-        formatted_answer = response.content,
+        formatted_answer = llm_response.answer,
+        citations=llm_response.citations,
         answer_query_config = AnswerQueryConfig(
             query=chat_message.dialog,
             query_generation_prompt = None,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,10 @@
 """Main module for the FastAPI application."""
+import json
 from fastapi import FastAPI
 
 from models.rate_models import RateRequest
 from models.chat_request import ChatRequest
+from models.llm_response import LlmResponse
 from models.chat_response import (
     Answer,
     AnswerQueryConfig,
@@ -54,9 +56,12 @@ def conversation(chat_message: ChatRequest):
     )
 
     response = chain.invoke({"question": chat_message.dialog})
+    json_content = json.loads(response.content)
+    llm_response = LlmResponse(**json_content)
+
     chat_answer = Answer(
-        formatted_answer = response["answer"],
-        citations = response["citations"],
+        formatted_answer = llm_response.answer,
+        citations=llm_response.citations,
         answer_query_config = AnswerQueryConfig(
             query=chat_message.dialog,
             query_generation_prompt = None,

--- a/backend/main.py
+++ b/backend/main.py
@@ -55,7 +55,8 @@ def conversation(chat_message: ChatRequest):
 
     response = chain.invoke({"question": chat_message.dialog})
     chat_answer = Answer(
-        formatted_answer = response.content,
+        formatted_answer = response["answer"],
+        citations = response["citations"],
         answer_query_config = AnswerQueryConfig(
             query=chat_message.dialog,
             query_generation_prompt = None,

--- a/backend/models/chat_response.py
+++ b/backend/models/chat_response.py
@@ -58,7 +58,6 @@ def to_answer_item(answer: Answer):
     """Returns a formatted item for the answer."""
     answer_item = {
         "formatted_answer": answer.formatted_answer,
-        "citations": answer.citations,
         "query_generation_prompt": answer.query_generation_prompt,
         "query": answer.query,
         "query_result": answer.query_result,

--- a/backend/models/chat_response.py
+++ b/backend/models/chat_response.py
@@ -52,7 +52,6 @@ class Answer:
         self.query_generation_prompt = answer_query_config.query_generation_prompt
         self.query = answer_query_config.query
         self.query_result = answer_query_config.query_result
-        self.citations = [] if citations is None else citations
 
 def to_answer_item(answer: Answer):
     """Returns a formatted item for the answer."""

--- a/backend/models/chat_response.py
+++ b/backend/models/chat_response.py
@@ -13,6 +13,19 @@ class ApproachType(Enum):
     INAPPROPRIATE = "5"
 
 @dataclass
+class Citation:
+    """Model for the citation."""
+    def __init__(
+        self,
+        id: str,
+        url: str,
+        title: str
+    ):
+        self.id = id
+        self.url = url
+        self.title = title
+
+@dataclass
 class AnswerQueryConfig:
     """Model for the answer query configuration."""
     def __init__(
@@ -32,11 +45,13 @@ class Answer:
         self,
         formatted_answer: str = "",
         answer_query_config: Optional[AnswerQueryConfig] = None,
+        citations: Optional[List[Citation]] = None,
     ):
         self.formatted_answer = formatted_answer
         self.query_generation_prompt = answer_query_config.query_generation_prompt
         self.query = answer_query_config.query
         self.query_result = answer_query_config.query_result
+        self.citations = [] if citations is None else citations
 
 def to_answer_item(answer: Answer):
     """Returns a formatted item for the answer."""
@@ -45,6 +60,7 @@ def to_answer_item(answer: Answer):
         "query_generation_prompt": answer.query_generation_prompt,
         "query": answer.query,
         "query_result": answer.query_result,
+        "citations": answer.citations
     }
     return answer_item
 

--- a/backend/models/chat_response.py
+++ b/backend/models/chat_response.py
@@ -35,10 +35,7 @@ class Answer:
         answer_query_config: Optional[AnswerQueryConfig] = None,
     ):
         self.formatted_answer = formatted_answer
-        if citations is None:
-            self.citations = []
-        else:
-            self.citations = citations
+        self.citations = [] if citations is None else citations
         self.query_generation_prompt = answer_query_config.query_generation_prompt
         self.query = answer_query_config.query
         self.query_result = answer_query_config.query_result

--- a/backend/models/chat_response.py
+++ b/backend/models/chat_response.py
@@ -31,9 +31,14 @@ class Answer:
     def __init__(
         self,
         formatted_answer: str = "",
+        citations: List[str] = None,
         answer_query_config: Optional[AnswerQueryConfig] = None,
     ):
         self.formatted_answer = formatted_answer
+        if citations is None:
+            self.citations = []
+        else:
+            self.citations = citations
         self.query_generation_prompt = answer_query_config.query_generation_prompt
         self.query = answer_query_config.query
         self.query_result = answer_query_config.query_result
@@ -42,6 +47,7 @@ def to_answer_item(answer: Answer):
     """Returns a formatted item for the answer."""
     answer_item = {
         "formatted_answer": answer.formatted_answer,
+        "citations": answer.citations,
         "query_generation_prompt": answer.query_generation_prompt,
         "query": answer.query,
         "query_result": answer.query_result,

--- a/backend/models/chat_response.py
+++ b/backend/models/chat_response.py
@@ -13,6 +13,19 @@ class ApproachType(Enum):
     INAPPROPRIATE = "5"
 
 @dataclass
+class Citation:
+    """Model for the citation."""
+    def __init__(
+        self,
+        id: str,
+        url: str,
+        title: str
+    ):
+        self.id = id
+        self.url = url
+        self.title = title
+
+@dataclass
 class AnswerQueryConfig:
     """Model for the answer query configuration."""
     def __init__(
@@ -31,14 +44,11 @@ class Answer:
     def __init__(
         self,
         formatted_answer: str = "",
-        citations: List[str] = None,
         answer_query_config: Optional[AnswerQueryConfig] = None,
+        citations: Optional[List[Citation]] = None,
     ):
         self.formatted_answer = formatted_answer
-        if citations is None:
-            self.citations = []
-        else:
-            self.citations = citations
+        self.citations = [] if citations is None else citations
         self.query_generation_prompt = answer_query_config.query_generation_prompt
         self.query = answer_query_config.query
         self.query_result = answer_query_config.query_result
@@ -47,10 +57,10 @@ def to_answer_item(answer: Answer):
     """Returns a formatted item for the answer."""
     answer_item = {
         "formatted_answer": answer.formatted_answer,
-        "citations": answer.citations,
         "query_generation_prompt": answer.query_generation_prompt,
         "query": answer.query,
         "query_result": answer.query_result,
+        "citations": answer.citations
     }
     return answer_item
 

--- a/backend/models/llm_response.py
+++ b/backend/models/llm_response.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+from models.chat_response import Citation
+
+@dataclass
+class LlmResponse:
+    answer: str
+    citations: list[Citation]
+    

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -36,8 +36,15 @@ export interface ChatRequest extends DialogRequest {
     overrides?: ChatRequestOverrides;
 }
 
+export type Citation = {
+    id: string;
+    url: string;
+    title: string;
+};
+
 export type Answer = {
     formatted_answer: string;
+    citations: Array<Citation>;
     query_generation_prompt?: string;
     query?: string;
     query_result?: string;

--- a/frontend/src/authconfig.ts
+++ b/frontend/src/authconfig.ts
@@ -1,0 +1,44 @@
+import { LogLevel, Configuration } from "@azure/msal-browser";
+
+export const msalConfig: Configuration = {
+    auth: {
+        clientId: "e97ea252-2fc4-4063-8375-4a3a9c57f725", // This is the ONLY mandatory field that you need to supply.
+        authority: "https://login.microsoftonline.com/ef93cf82-da30-4e5b-8b45-3342cdca86ec/", // Replace the placeholder with your tenant subdomain
+        redirectUri: "/", // Points to window.location.origin. You must register this URI on Azure Portal/App Registration.
+        postLogoutRedirectUri: "/", // Indicates the page to navigate after logout.
+        navigateToLoginRequestUrl: false // If "true", will navigate back to the original request location before processing the auth code response.
+    },
+    cache: {
+        cacheLocation: "sessionStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
+        storeAuthStateInCookie: false // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {
+                    return;
+                }
+                switch (level) {
+                    case LogLevel.Error:
+                        console.error(message);
+                        return;
+                    case LogLevel.Info:
+                        console.info(message);
+                        return;
+                    case LogLevel.Verbose:
+                        console.debug(message);
+                        return;
+                    case LogLevel.Warning:
+                        console.warn(message);
+                        return;
+                    default:
+                        return;
+                }
+            }
+        }
+    }
+};
+
+export const loginRequest = {
+    scopes: []
+};

--- a/frontend/src/authconfig.ts
+++ b/frontend/src/authconfig.ts
@@ -1,0 +1,44 @@
+import { LogLevel, Configuration } from "@azure/msal-browser";
+
+export const msalConfig: Configuration = {
+    auth: {
+        clientId: "CLIENTID", // This is the ONLY mandatory field that you need to supply.
+        authority: "https://login.microsoftonline.com/TENANTID/", // Replace the placeholder with your tenant subdomain
+        redirectUri: "/", // Points to window.location.origin. You must register this URI on Azure Portal/App Registration.
+        postLogoutRedirectUri: "/", // Indicates the page to navigate after logout.
+        navigateToLoginRequestUrl: false // If "true", will navigate back to the original request location before processing the auth code response.
+    },
+    cache: {
+        cacheLocation: "sessionStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
+        storeAuthStateInCookie: false // Set this to "true" if you are having issues on IE11 or Edge
+    },
+    system: {
+        loggerOptions: {
+            loggerCallback: (level, message, containsPii) => {
+                if (containsPii) {
+                    return;
+                }
+                switch (level) {
+                    case LogLevel.Error:
+                        console.error(message);
+                        return;
+                    case LogLevel.Info:
+                        console.info(message);
+                        return;
+                    case LogLevel.Verbose:
+                        console.debug(message);
+                        return;
+                    case LogLevel.Warning:
+                        console.warn(message);
+                        return;
+                    default:
+                        return;
+                }
+            }
+        }
+    }
+};
+
+export const loginRequest = {
+    scopes: []
+};

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -102,10 +102,9 @@ export const Answer = ({
                     <Stack horizontal wrap tokens={{ childrenGap: 5 }}>
                         <span className={styles.citationLearnMore}>Citations:</span>
                         {parsedAnswer.citations.map((x, i) => {
-                            const path = getCitationFilePath(x);
                             return (
-                                <a key={i} className={styles.citation} title={x} onClick={() => onCitationClicked(path)}>
-                                    {`${++i}. ${x}`}
+                                <a key={i} className={styles.citation} title={x.title} onClick={() => onCitationClicked(x.url)}>
+                                    {`${++i}. ${x.title}`}
                                 </a>
                             );
                         })}

--- a/frontend/src/components/Answer/AnswerParser.tsx
+++ b/frontend/src/components/Answer/AnswerParser.tsx
@@ -1,14 +1,14 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { ApproachType, ChatResponse, getCitationFilePath } from "../../api";
+import { ApproachType, ChatResponse, Citation, getCitationFilePath } from "../../api";
 
 type HtmlParsedAnswer = {
     answerHtml: string;
-    citations: string[];
+    citations: Citation[];
     followupQuestions: string[];
 };
 
 export function parseAnswerToHtml(chatResponse: ChatResponse, onCitationClicked: (citationFilePath: string) => void): HtmlParsedAnswer {
-    const citations: string[] = [];
+    const citations: Citation[] = [];
     const followupQuestions: string[] = [];
 
     // Extract any follow-up questions that might be in the answer
@@ -21,28 +21,10 @@ export function parseAnswerToHtml(chatResponse: ChatResponse, onCitationClicked:
     parsedAnswer = parsedAnswer.trim();
 
     var fragments: string[] = [];
-    const parts = chatResponse.classification == ApproachType.Unstructured ? parsedAnswer.split(/\{([^}]+)\}/g) : [parsedAnswer];
-    fragments = parts.map((part, index) => {
-        if (index % 2 === 0) {
-            return part;
-        } else {
-            // Extract citations from answer
-            let citationIndex: number;
-            if (citations.indexOf(part) !== -1) {
-                citationIndex = citations.indexOf(part) + 1;
-            } else {
-                citations.push(part);
-                citationIndex = citations.length;
-            }
-
-            const path = getCitationFilePath(part);
-
-            return renderToStaticMarkup(
-                <a className="supContainer" title={part} onClick={() => onCitationClicked(path)}>
-                    <sup>{citationIndex}</sup>
-                </a>
-            );
-        }
+    //const parts = chatResponse.classification == ApproachType.Unstructured ? parsedAnswer.split(/\{([^}]+)\}/g) : [parsedAnswer];
+    fragments = chatResponse.answer.citations.map((citation, index) => {
+        citations.push(citation);
+        return parsedAnswer;
     });
 
     return {


### PR DESCRIPTION
Pete did most of the work getting this to use the front end's already built-in citation display.

Adds support for returning citations as part of the response object in the `Answer` model. The `Answer` model now includes a `citations` field, which is an array of `Citation` objects. The `Citation` object contains the `id`, `url`, and `title` of the citation. This allows for proper citation of the sources used to generate the answer.